### PR TITLE
chisel fixes v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,12 @@ These fixes are intended to be used with a particular 100+ mod server configurat
 
 ### Chisel Recovery Reduction
 - Metal Plates now return 20 bits instead of 40
+- Most metal recovery recipes with Chisels now return 10 bits.
+
+### CombatOverhaul Changes
+- Bears have been reduced from tiers (4, 5, 4, 4, 5) to (2, 3, 2, 2, 3) to be in line with base-game
+- This patch WILL FAIL if you do not have CombatOverhaul, but is not destructive if you lack it.
+
+### Rust Magic Changes
+- Elemental Sentries damage has been reduced from 3.5 to 2.5, to be in line with other damage reduction changes
+- This patch WILL FAIL if you do not have RustMagic, but it is not destructive if you lack it.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ These fixes are intended to be used with a particular 100+ mod server configurat
 
 ### CombatOverhaul Changes
 - Bears have been reduced from tiers (4, 5, 4, 4, 5) to (2, 3, 2, 2, 3) to be in line with base-game
-- This patch WILL FAIL if you do not have CombatOverhaul, but is not destructive if you lack it.
+- This patch WILL FAIL if you do not have [Combat Overhaul](https://mods.vintagestory.at/combatoverhaul), but is not destructive if you lack it.
 
 ### Rust Magic Changes
 - Elemental Sentries damage has been reduced from 3.5 to 2.5, to be in line with other damage reduction changes
-- This patch WILL FAIL if you do not have RustMagic, but it is not destructive if you lack it.
+- This patch WILL FAIL if you do not have [Rustbound Magic](https://mods.vintagestory.at/rustboundmagic), but it is not destructive if you lack it.

--- a/ZathsModFixes/modinfo.json
+++ b/ZathsModFixes/modinfo.json
@@ -1,12 +1,12 @@
 {
     "type": "code",
     "modid": "zathsmodfixes",
-    "name": "ZathsModFixes",
+    "name": "zathsmodfixes",
     "authors": [
         "Zathael"
     ],
     "description": "Fixes and tweaks for recipes and game balance.",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "dependencies": {
         "game": "1.20.0"
     }

--- a/ZathsModFixes/resources/assets/zathsmodfixes/patches/compatibility/combatoverhaul/entities/bear.json
+++ b/ZathsModFixes/resources/assets/zathsmodfixes/patches/compatibility/combatoverhaul/entities/bear.json
@@ -1,0 +1,28 @@
+[
+    {
+        "side": "Server",
+        "file": "game:entities/land/bear",
+        "op": "replace",
+        "path": "/server/behaviors/9/aitasks/0/damageTierByType",
+        "value": {
+            "*-black": 2,
+            "*-brown": 3,
+            "*-sun": 2,
+            "*-panda": 2,
+            "*-polar": 3
+        }
+    },
+    {
+        "side": "Server",
+        "file": "game:entities/land/bear",
+        "op": "replace",
+        "path": "/server/behaviors/9/aitasks/1/damageTierByType",
+        "value": {
+            "*-black": 2,
+            "*-brown": 3,
+            "*-sun": 2,
+            "*-panda": 2,
+            "*-polar": 3
+        }
+    }
+]

--- a/ZathsModFixes/resources/assets/zathsmodfixes/patches/compatibility/combatoverhaul/entities/rustboundmagic/entityelementalsentry.json
+++ b/ZathsModFixes/resources/assets/zathsmodfixes/patches/compatibility/combatoverhaul/entities/rustboundmagic/entityelementalsentry.json
@@ -1,0 +1,8 @@
+[
+    {
+        "op": "replace",
+        "file": "rustboundmagic:entities/creatures/elementals/sentry/entityelementalsentry",
+        "path": "/server/behaviors/7/aitasks/0/damageDoneByType/*-common",
+        "value": 2.5
+    }
+]

--- a/ZathsModFixes/resources/assets/zathsmodfixes/patches/recipes/chiselworkitem.json
+++ b/ZathsModFixes/resources/assets/zathsmodfixes/patches/recipes/chiselworkitem.json
@@ -1,5 +1,4 @@
-﻿// smithingplus sets this to 20, we need to reduce
-[
+﻿[
     {
         "op": "replace",
         "file": "smithingplus:recipes/grid/chiselworkitem",

--- a/ZathsModFixes/resources/assets/zathsmodfixes/patches/recipes/chiselworkitem.json
+++ b/ZathsModFixes/resources/assets/zathsmodfixes/patches/recipes/chiselworkitem.json
@@ -1,0 +1,9 @@
+﻿// smithingplus sets this to 20, we need to reduce
+[
+    {
+        "op": "replace",
+        "file": "smithingplus:recipes/grid/chiselworkitem",
+        "path": "/0/output/quantity",
+        "value": 10
+    }
+]

--- a/ZathsModFixes/resources/assets/zathsmodfixes/patches/recipes/metalbit.json
+++ b/ZathsModFixes/resources/assets/zathsmodfixes/patches/recipes/metalbit.json
@@ -2,7 +2,37 @@
     {
         "op": "replace",
         "file": "game:recipes/grid/metalbit",
+        "path": "/0/output/quantity",
+        "value": 10
+    },
+    {
+        "op": "replace",
+        "file": "game:recipes/grid/metalbit",
         "path": "/1/output/quantity",
         "value": 20
+    },
+    {
+        "op": "replace",
+        "file": "game:recipes/grid/metalbit",
+        "path": "/2/output/quantity",
+        "value": 10
+    },
+    {
+        "op": "replace",
+        "file": "game:recipes/grid/metalbit",
+        "path": "/3/output/quantity",
+        "value": 10
+    },
+    {
+        "op": "replace",
+        "file": "game:recipes/grid/metalbit",
+        "path": "/4/output/quantity",
+        "value": 10
+    },
+    {
+        "op": "replace",
+        "file": "game:recipes/grid/metalbit",
+        "path": "/5/output/quantity",
+        "value": 10
     }
 ]


### PR DESCRIPTION
wow, so many random mods love to add +recipes to the metalbits recipes book
and then not consider that people can potentially, idk, use the dang recipe

### VANILLA CHISELING METAL DUPLICATION CONCERNS
- fixes numerous mods increasing this value to be equal to the input, when you can get extra bits then chisel back down for infinite metal from nothing. you now get about 10 bits each time.
- covers for chiseltools item types
- covers for any other mod trying to speed up these base values

### MOD RENAMING FOR MAXIMUM EFFECTIVENESS
- mod name renamed since "za" is unicode index 122,97 vs "Za" unicode index 90,97. we want this to happen =last=

### COMBAT OVERHAUL COMPATIBILITY PATCH - BEAR NERF
`BEAR TYPE | BASE GAME TIER | COMBAT OVERHAUL TIER | NOW`
`black | 2 | 4 | 2`
`brown | 2 | 5 | 3`
`sun | 2 | 4 | 2`
`panda | 2 | 4 | 2`
`polar | 2 | 5 | 3`

### RUSTBOUND MAGIC COMPATIBILITY PATCH - SENTRY DAMAGE ADJUSTMENT
to keep in line with the ~20-40% damage reduction across all creatures from combat overhaul

ElementalSentryMagicDamage 3.5 => 2.5
